### PR TITLE
Add vim syntax highlighting

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -3,3 +3,15 @@
 ## [VSCODE](./vscode/)
 
 Nuru syntax highlighting on VSCode
+
+## [VIM](./vim)
+
+The file contained herein has a basic syntax highlight for vim.
+The file should be saved in `$HOME/.vim/syntax/nuru.vim`.
+You should add the following line to your `.vimrc` or the appropriate location:
+
+```vim
+au BufRead,BufNewFile *.nr set filetype=nuru
+```
+
+Only basic syntax highlighting is provided by the script.

--- a/extensions/vim/syntax/nuru.vim
+++ b/extensions/vim/syntax/nuru.vim
@@ -1,0 +1,51 @@
+" Sintaksia ya nuru kwenye programu ya "vim"
+" Lugha: Nuru
+
+" Maneno tengwa
+syntax keyword nuruKeyword unda pakeji rudisha vunja endelea tupu
+syntax keyword nuruType fanya
+syntax keyword nuruBool kweli sikweli
+syntax keyword nuruConditional kama sivyo au
+syntax match nuruComparision /[!\|<>]/
+syntax keyword nuruLoop ktk while badili
+syntax keyword nuruLabel ikiwa kawaida
+
+" Nambari
+syntax match nuruInt '[+-]\d\+' contained display
+syntax match nuruFloat '[+-]\d+\.\d*' contained display
+
+" Viendeshaji
+syntax match nuruAssignment '='
+syntax match nuruLogicalOP /[\&!|]/
+
+" Vitendakazi 
+syntax keyword nuruFunction andika aina jaza fungua
+
+" Tungo
+syntax region nuruString start=/"/ skip=/\\"/ end=/"/
+syntax region nuruString start=/'/ skip=/\\'/ end=/'/
+
+" Maoni
+syntax match nuruComment "//.*"
+syntax region nuruComment start="/\*" end="\*/"
+
+" Fafanua sintaksia
+let b:current_syntax = "nuru"
+
+highlight def link nuruComment Comment
+highlight def link nuruBool Boolean
+highlight def link nuruFunction Function
+highlight def link nuruComparision Conditional
+highlight def link nuruConditional Conditional
+highlight def link nuruKeyword Keyword
+highlight def link nuruString String
+highlight def link nuruVariable Identifier
+highlight def link nuruLoop Repeat
+highlight def link nuruInt Number
+highlight def link nuruFloat Float
+highlight def link nuruAssignment Operator
+highlight def link nuruLogicalOP Operator
+highlight def link nuruAriOP Operator
+highlight def link nuruType Type
+highlight def link nuruLabel Label
+


### PR DESCRIPTION
A trial to try and enable syntax highlighting for vim users

The following are highlighted:

- Keywords
- Types (most)
- Operators (most)
- Comments (better but not yet there)

Only the definition is done, the actual highlighting (colours) is done
by vim itself.
A good theme is also a good investment in this case.

This syntax highlighting `MAY` not work with neovim.
No tests (opening and closing the files) were done.
I currently don't have neovim so the burden falls to the future entity.

Vim needs to be told of the syntax highlighting to actually work.
This can be done through:

```vim
au BufRead,BufBewFile *.nr set filetype=nuru
```

When the above line is inserted everything should work as
expected.

Signed-off-by: Gekko Wrld <gekkowrld@gmail.com>
