### PR TITLE
Handle `nil` dereference in expressions

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -45,7 +45,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return left
 		}
 		right := Eval(node.Right, env)
-		if isError(right) {
+		if isError(right) && right != nil {
 			return right
 		}
 		return evalInfixExpression(node.Operator, left, right, node.Token.Line)

--- a/evaluator/infix.go
+++ b/evaluator/infix.go
@@ -8,6 +8,9 @@ import (
 )
 
 func evalInfixExpression(operator string, left, right object.Object, line int) object.Object {
+	if right == nil {
+		return newError("Mstari %d: Umekosea hapa", line)
+			}
 	if left == nil {
 		return newError("Mstari %d: Umekosea hapa", line)
 	}


### PR DESCRIPTION
The code will fail if the second arg is `nil`
then the code will fail with a panic.

Fixes: https://github.com/NuruProgramming/Nuru/issues/79

Before only the left arg was checked for `nil` but not the
right arg.

Signed-off-by: Gekko Wrld <gekkowrld@gmail.com>