### PR TITLE
docs: Improve Android (Termux) installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To install Nuru on your Android device using Termux, follow these steps:
 
 3. **Download the Nuru package**:
    ```bash
-   curl -O -L https://github.com/AvicennaJr/Nuru/releases/download/v0.5.16/nuru_Android_arm64.tar.gz
+   curl -O -L https://github.com/NuruProgramming/Nuru/releases/download/v0.5.16/nuru_Android_arm64.tar.gz
    ```
 
 4. **Extract the files to the target directory**:

--- a/README.md
+++ b/README.md
@@ -72,29 +72,51 @@ nuru -v
 ```
 
 
+
+
 ### Android (Termux)
 
- - Make sure you have [Termux](https://f-droid.org/repo/com.termux_118.apk) installed.
- - Download the binary with this command:
+To install Nuru on your Android device using Termux, follow these steps:
 
-```
-curl -O -L https://github.com/AvicennaJr/Nuru/releases/download/v0.5.16/nuru_Android_arm64.tar.gz
-```
- - Extract the file:
+1. **Ensure Termux is installed**:
+   - You can download and install [Termux](https://f-droid.org/en/packages/com.termux/).
 
-```
-tar -xzvf nuru_Android_arm64.tar.gz
-```
- - Add it to path:
+2. **Create the target directory**:
+   ```bash
+   mkdir -p /data/data/com.termux/files/usr/share/nuru
+   ```
 
-```
-echo "alias nuru='~/nuru'" >> .bashrc
-```
- - Confirm installation with:
+3. **Download the Nuru package**:
+   ```bash
+   curl -O -L https://github.com/AvicennaJr/Nuru/releases/download/v0.5.16/nuru_Android_arm64.tar.gz
+   ```
 
+4. **Extract the files to the target directory**:
+   ```bash
+   tar -xzvf nuru_Android_arm64.tar.gz -C /data/data/com.termux/files/usr/share/nuru
+   ```
+
+5. **Set up an alias for easy access**:
+   ```bash
+   echo "alias nuru='/data/data/com.termux/files/usr/share/nuru/nuru'" >> ~/.bashrc
+   ```
+
+6. **Reload the .bashrc file to apply the alias**:
+   ```bash
+   source ~/.bashrc
+   ```
+
+7. **Verify the installation**:
+   ```bash
+   nuru -v
+   ```
+
+For a more streamlined installation, you can use the following one-liner:
+
+```bash
+curl -O -L https://github.com/AvicennaJr/Nuru/releases/download/v0.5.16/nuru_Android_arm64.tar.gz && mkdir -p /data/data/com.termux/files/usr/share/nuru && tar -xzvf nuru_Android_arm64.tar.gz -C /data/data/com.termux/files/usr/share/nuru && echo "alias nuru='/data/data/com.termux/files/usr/share/nuru/nuru'" >> ~/.bashrc && source ~/.bashrc && echo "Installation complete.."
 ```
-nuru -v 
-```
+
 
 ### Windows
 


### PR DESCRIPTION

- Detailed step-by-step guide to ensure clear and successful installation:
  - Ensure Termux installation from F-Droid.
  - Create the necessary target directory for Nuru.
  - Download the Nuru package from GitHub releases.
  - Extract the downloaded package to the specified directory.
  - Set up a convenient alias for easy access to Nuru.
  - Reload .bashrc to apply the newly created alias.
  - Verify the installation by checking the Nuru version.

- Added a one-liner installation command for advanced users:
  - This command streamlines the entire installation process into a single line, making it quick and easy to execute.

- Improved flexibility and clarity of instructions to cater to both beginners and advanced users:
  - Step-by-step instructions provide a detailed and clear path for users unfamiliar with the process.
  - The one-liner command offers a fast and efficient alternative for users who prefer a quicker installation method.
  
- Ensured the documentation is comprehensive and user-friendly to prevent installation issues and enhance user experience.

### Screenshot of the smooth installation
![Screenshot_20240605-141615](https://github.com/NuruProgramming/Nuru/assets/76619967/6699ce97-aa23-4a58-a24b-36e9dfc2cf1f)

